### PR TITLE
[libx11] set environment variable DEBIAN_FRONTEND

### DIFF
--- a/libx11/docker-image/SubuserImagefile
+++ b/libx11/docker-image/SubuserImagefile
@@ -1,3 +1,4 @@
 FROM debian
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN TERM=linux apt-get install -y x11-common x11-utils libx11-6


### PR DESCRIPTION
This will remove the following issue when running `apt-get`.

```
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog
based frontend cannot be used. at
/usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
```
