### PR TITLE
Add the game 'Battle For Wesnoth': https://www.wesnoth.org/

### DIFF
--- a/wesnoth-base/image/SubuserImagefile
+++ b/wesnoth-base/image/SubuserImagefile
@@ -1,0 +1,14 @@
+FROM-SUBUSER-IMAGE libx11@default
+ENV DEBIAN_FRONTEND noninteractive
+
+# Add backports repository for Debian, containing Battle For Wesnoth 1.12
+ADD backports.list /etc/apt/sources.list.d/backports.list
+
+# update + upgrade + install locales and wesnoth
+# the locales package is needed for the issue below 
+RUN apt-get update && apt-get upgrade -yq && \
+    apt-get install -yq apt-utils locales 'wesnoth-1.12*'
+
+# solves the issue:
+# locale::facet::_S_create_c_locale name not valid
+RUN sed -Ei 's/# (en_US.UTF-8 UTF-8)/\1/g' /etc/locale.gen && locale-gen

--- a/wesnoth-base/image/backports.list
+++ b/wesnoth-base/image/backports.list
@@ -1,0 +1,2 @@
+# Backports repository
+deb http://httpredir.debian.org/debian jessie-backports main contrib non-free

--- a/wesnoth-base/permissions.json
+++ b/wesnoth-base/permissions.json
@@ -1,0 +1,12 @@
+{
+ "description"                : "Battle for Wesnoth",
+ "maintainer"                 : "Cristian Consonni <kikkocristian (at) gmail (dot) com",
+ "executable"                 : "/usr/games/wesnoth-1.12",
+ "gui"                        : {"cursors": true},
+ "sound-card"                 : true,
+ "allow-network-access"       : true,
+ "basic-common-permissions"   : true,
+ "stateful-home"              : true,
+ "inherit-locale"             : true,
+ "inherit-timezone"           : true
+}

--- a/wesnoth/image/SubuserImagefile
+++ b/wesnoth/image/SubuserImagefile
@@ -1,0 +1,3 @@
+FROM-SUBUSER-IMAGE wesnoth-base
+RUN apt-get update && apt-get upgrade -yq
+ADD check-for-updates /subuser/check-for-updates

--- a/wesnoth/image/check-for-updates
+++ b/wesnoth/image/check-for-updates
@@ -1,0 +1,6 @@
+#!/bin/bash
+apt-get update
+apt-get upgrade --show-upgraded --assume-no
+[ $? -eq 0 ] && exit 1
+[ $? -eq 1 ] && exit 0
+

--- a/wesnoth/permissions.json
+++ b/wesnoth/permissions.json
@@ -1,0 +1,12 @@
+{
+ "description"                : "Battle for Wesnoth",
+ "maintainer"                 : "Cristian Consonni <kikkocristian (at) gmail (dot) com",
+ "executable"                 : "/usr/games/wesnoth-1.12",
+ "gui"                        : {"cursors": true},
+ "sound-card"                 : true,
+ "allow-network-access"       : true,
+ "basic-common-permissions"   : true,
+ "stateful-home"              : true,
+ "inherit-locale"             : true,
+ "inherit-timezone"           : true
+}


### PR DESCRIPTION
As per the pull request title, this commit adds two subuser images:
* `wesnoth-base`
* `wesnoth`

containing version `1.12.6` of _"Battle for Wesnoth"_, [www.wesnoth.org](https:///www.wesnoth.org): a free/libre "turn-based tactical strategy game". The game is available through the "backports" repository on Debian.

I have followed the structure of the images of `briquolo`. I have tested the image with `subuser dev`.

I am not able to reproduce any sound from the game and manipulating the sound preferencis will give the following errors (in the terminal from which the subuser has been launched):
```
ALSA lib pcm_dmix.c:1022:(snd_pcm_dmix_open) unable to open slave
20161228 00:50:50 error audio: Could not initialize audio: No available audio device
```

I am not sure if these errors are related to the other sound issues, see https://github.com/subuser-security/subuser-default-repository/issues/7 and https://github.com/subuser-security/subuser/issues/242.