### PR TITLE
update filefox and thunderbird names

### DIFF
--- a/libdebian/image/SubuserImagefile
+++ b/libdebian/image/SubuserImagefile
@@ -6,5 +6,5 @@ RUN apt-get update -qq && apt-get install -y locales -qq && locale-gen en_US.UTF
 ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
-RUN apt-get install -yqq iceweasel icedove emacs git irssi keepassx libreoffice pandoc vim
+RUN apt-get install -yqq firefox-esr thunderbird emacs git irssi keepassx libreoffice pandoc vim
 ONBUILD RUN apt-get update && apt-get upgrade -y


### PR DESCRIPTION
I have updated the packages, so that they work again: firefox and icedove are no longer in debian, and the packages depended on debian:latest. debian:latest now points to debian stable (Buster).

This fixes https://github.com/subuser-security/subuser/issues/349

These are still some packages pointing to debian old-stable (e.g. xpra), this is causing two copies of debian to be pulled.