### PR TITLE
Update wesnoth

### DIFF
--- a/wesnoth-base/image/SubuserImagefile
+++ b/wesnoth-base/image/SubuserImagefile
@@ -1,13 +1,10 @@
 FROM-SUBUSER-IMAGE libx11@default
 ENV DEBIAN_FRONTEND noninteractive
 
-# Add backports repository for Debian, containing Battle For Wesnoth 1.12
-ADD backports.list /etc/apt/sources.list.d/backports.list
-
 # update + upgrade + install locales and wesnoth
 # the locales package is needed for the issue below 
 RUN apt-get update && apt-get upgrade -yq && \
-    apt-get install -yq apt-utils locales 'wesnoth-1.12*'
+    apt-get install -yq apt-utils locales wesnoth
 
 # solves the issue:
 # locale::facet::_S_create_c_locale name not valid

--- a/wesnoth-base/permissions.json
+++ b/wesnoth-base/permissions.json
@@ -1,12 +1,15 @@
 {
- "description"                : "Battle for Wesnoth",
- "maintainer"                 : "Cristian Consonni <kikkocristian (at) gmail (dot) com",
- "executable"                 : "/usr/games/wesnoth-1.12",
- "gui"                        : {"cursors": true},
- "sound-card"                 : true,
- "allow-network-access"       : true,
- "basic-common-permissions"   : true,
- "stateful-home"              : true,
- "inherit-locale"             : true,
- "inherit-timezone"           : true
+	"description": "Battle for Wesnoth",
+	"maintainer": "Cristian Consonni <cristian (at) balist (dot) es",
+	"executable": "/usr/games/wesnoth",
+	"gui": {
+		"cursors": true
+	},
+	"sound-card": true,
+	"allow-network-access": true,
+	"basic-common-permissions": {
+		"stateful-home": true,
+		"inherit-locale": true,
+		"inherit-timezone": true
+	}
 }

--- a/wesnoth/permissions.json
+++ b/wesnoth/permissions.json
@@ -1,12 +1,15 @@
 {
- "description"                : "Battle for Wesnoth",
- "maintainer"                 : "Cristian Consonni <kikkocristian (at) gmail (dot) com",
- "executable"                 : "/usr/games/wesnoth-1.12",
- "gui"                        : {"cursors": true},
- "sound-card"                 : true,
- "allow-network-access"       : true,
- "basic-common-permissions"   : true,
- "stateful-home"              : true,
- "inherit-locale"             : true,
- "inherit-timezone"           : true
+	"description": "Battle for Wesnoth",
+	"maintainer": "Cristian Consonni <cristian (at) balist (dot) es",
+	"executable": "/usr/games/wesnoth",
+	"gui": {
+		"cursors": true
+	},
+	"sound-card": true,
+	"allow-network-access": true,
+	"basic-common-permissions": {
+		"stateful-home": true,
+		"inherit-locale": true,
+		"inherit-timezone": true
+	}
 }


### PR DESCRIPTION
This PR updates the Battle for Wesnoth subuser (both ẁesnoth-base` and `wesnoth`). I have removed the backport repository because it is not necessary anymore.

Also, audio works with the option `sound-card: true`, I could not make it work with `pulseaudio`.