### PR TITLE
Update xpra-base/image/SubuserImagefile

### DIFF
--- a/xpra-base/image/SubuserImagefile
+++ b/xpra-base/image/SubuserImagefile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:oldstable
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y
 RUN TERM=linux apt-get install -y xpra


### PR DESCRIPTION
Installing subuser images with the superseded Debian 9 container image from 5-8 years ago is not working, the packages repository doesn't have "stretch" releases.

Internal, failing to build, "`xpra`" client & server service subusers come with *this* "`xpra-base`" image in the default subuser repository, this uses Debian 9 codename "stretch".